### PR TITLE
Split source_root directory creation and django project start command

### DIFF
--- a/hooks/pre_gen_project.sh
+++ b/hooks/pre_gen_project.sh
@@ -21,6 +21,7 @@ fi
 
 {{ cookiecutter.virtualenv_bin }} .ve
 .ve/bin/pip install -q "django=={{ cookiecutter.django_version }}"
-mkdir "$source_root" && .ve/bin/django-admin.py startproject -v 0 "{{ cookiecutter.project_name }}" "{{ cookiecutter.source_root }}"
+mkdir "$source_root"
+.ve/bin/django-admin.py startproject -v 0 "{{ cookiecutter.project_name }}" "{{ cookiecutter.source_root }}"
 
 echo "---> DONE Running pre-hook script..."


### PR DESCRIPTION
This PR fixes #3 by splitting the `source_root` directory creation from the Django `startproject` command. Now if the `source_root` directory creation fails the `startproject` command will still run.